### PR TITLE
Corrected bug with Delete button on index.php.

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1,13 +1,5 @@
 <?php
 
-//NOTES: 
-//12/10/21: INTERMITTENT ERROR WITH DELETING. CONFIRM DIALOG BOX NOT POPPING UP ON NEWER ENTRIES TO TABLE ADDED THROUGH INTERFACE.
-//  NOT SURE WHAT HAPPENS WHEN ADDED THROUGH QUERY ANALYZER. 
-//
-//12/12/21: CANNOT REPLICATE THE ERROR FROM 12/10/21. ONLY DIFFERENCE IS I'M WORKING ON A DIFFERENT COMPUTER TODAY. I
-//  CANNOT SEE WHY THAT WOULD MAKE A DIFFERENCE, BUT IT SEEMS TO. NEED TO INVESTIGATE FURTHER.
-
-
 
 require_once('../search.php');
 
@@ -80,10 +72,13 @@ require_once('../search.php');
                             <!--Deletions should done through Post, not Get, so  using a 
                                 form instead of an anchor tag to pass hidden information
                                 to be used in a post request-->
-        
+                            
+
+                            <?php $nameWithoutQuotes = str_replace(array('"',"'"), "",$boardgame['name']);?>
+
                             <form style="display: inline-block" method="post" action="delete.php">
                                 <input type="hidden" name="id" value="<?php echo $boardgame['id'] ?>">
-                                <button type="submit" class="btn btn-sm btn-danger mb-2" onClick="return confirm('Are you sure you want to delete <?php echo $boardgame['name'];?>?')">Delete</button>
+                                <button type="submit" class="btn btn-sm btn-danger mb-2" onclick="return confirm_delete('<?php echo $nameWithoutQuotes ?>')">Delete</button>
                             </form>
                         </td>
                         
@@ -99,5 +94,7 @@ require_once('../search.php');
 
 
     </div>
+
+
 </body>
 </html>

--- a/views/partials/header.php
+++ b/views/partials/header.php
@@ -10,4 +10,11 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <link rel="stylesheet" href="/app.css"> 
     <title>Board Game Library</title>
+
+    <script type="text/javascript">
+        function confirm_delete(game){
+            return confirm('Are you sure you want to delete ' + game + '?');
+        }
+    </script>
+
 </head>


### PR DESCRIPTION
Intermittent error where confirm dialog box was not appearing when Delete button was pressed. Discovered the cause was game names with single or double quotes within them. Corrected by creating a variable before the button that has the game name with single and double quotes removed, then passing that variable to be displayed in the delete confirm message.